### PR TITLE
Add "Mark Complete" button to activity show page

### DIFF
--- a/lib/squeeze_web/controllers/activity_controller.ex
+++ b/lib/squeeze_web/controllers/activity_controller.ex
@@ -25,6 +25,7 @@ defmodule SqueezeWeb.ActivityController do
         conn
         |> put_flash(:info, "Activity created successfully.")
         |> redirect(to: Routes.activity_path(conn, :show, activity))
+
       {:error, %Ecto.Changeset{} = changeset} ->
         conn
         |> put_status(:unprocessable_entity)
@@ -51,6 +52,7 @@ defmodule SqueezeWeb.ActivityController do
         conn
         |> put_flash(:info, "Activity updated successfully.")
         |> redirect(to: Routes.activity_path(conn, :show, activity))
+
       {:error, %Ecto.Changeset{} = changeset} ->
         render(conn, "edit.html", activity: activity, changeset: changeset)
     end
@@ -63,6 +65,22 @@ defmodule SqueezeWeb.ActivityController do
     conn
     |> put_flash(:info, "Activity deleted successfully.")
     |> redirect(to: Routes.activity_path(conn, :index))
+  end
+
+  def mark_complete(conn, %{"activity_id" => id}, user) do
+    activity = Dashboard.get_activity!(user, id)
+
+    case Dashboard.update_activity(activity, %{"complete" => true}) do
+      {:ok, activity} ->
+        conn
+        |> put_flash(:info, "Activity completed!")
+        |> redirect(to: Routes.activity_path(conn, :show, activity))
+
+      {:error, %Ecto.Changeset{} = _changeset} ->
+        conn
+        |> put_flash(:info, "Could not mark activity as completed.")
+        |> redirect(to: Routes.activity_path(conn, :show, activity))
+    end
   end
 
   defp trackpoints(%{trackpoint_set: nil}), do: []

--- a/lib/squeeze_web/router.ex
+++ b/lib/squeeze_web/router.ex
@@ -27,7 +27,8 @@ defmodule SqueezeWeb.Router do
   end
 
   scope "/", SqueezeWeb do
-    pipe_through :browser # Use the default browser stack
+    # Use the default browser stack
+    pipe_through :browser
 
     get "/", HomeController, :index
 
@@ -55,7 +56,8 @@ defmodule SqueezeWeb.Router do
   end
 
   scope "/integration", SqueezeWeb do
-    pipe_through :browser # Use the default browser stack
+    # Use the default browser stack
+    pipe_through :browser
 
     get "/:provider", IntegrationController, :request
     get "/:provider/callback", IntegrationController, :callback
@@ -63,7 +65,8 @@ defmodule SqueezeWeb.Router do
   end
 
   scope "/auth", SqueezeWeb do
-    pipe_through :browser # Use the default browser stack
+    # Use the default browser stack
+    pipe_through :browser
 
     get "/:provider", AuthController, :request
     get "/:provider/callback", AuthController, :callback
@@ -85,10 +88,11 @@ defmodule SqueezeWeb.Router do
     get "/billing", BillingController, :index
     put "/billing/cancel", BillingController, :cancel
 
-    resources "/payment", PaymentMethodController,
-      only: [:index, :new, :create, :delete]
+    resources "/payment", PaymentMethodController, only: [:index, :new, :create, :delete]
 
-    resources "/activities", ActivityController
+    resources "/activities", ActivityController do
+      patch "/mark-complete", ActivityController, :mark_complete, as: :mark_complete
+    end
 
     resources "/plans", PlanController
   end
@@ -103,7 +107,7 @@ defmodule SqueezeWeb.Router do
     post "/stripe", StripeWebhookController, :webhook
   end
 
-  if Mix.env == :dev do
+  if Mix.env() == :dev do
     forward "/sent_emails", Bamboo.SentEmailViewerPlug
   end
 end

--- a/lib/squeeze_web/templates/activity/show.html.eex
+++ b/lib/squeeze_web/templates/activity/show.html.eex
@@ -22,6 +22,9 @@
       </p>
     </div>
     <div class="col text-right">
+      <%= if @activity.status == :pending do %>
+        <%= link(gettext("Mark Complete"), to: Routes.activity_mark_complete_path(@conn, :mark_complete, @activity.id), class: "btn btn-primary btn-sm", method: :patch) %>
+      <% end %>
       <%= link(gettext("Edit"), to: Routes.activity_path(@conn, :edit, @activity), class: "btn btn-sm btn-secondary") %>
       <%= link(gettext("Delete"), to: Routes.activity_path(@conn, :delete, @activity), class: "btn btn-sm btn-danger", method: :delete,
         data: [confirm: gettext("Are you sure you want to delete this activity?")]) %>

--- a/test/squeeze_web/controllers/activity_controller_test.exs
+++ b/test/squeeze_web/controllers/activity_controller_test.exs
@@ -4,21 +4,21 @@ defmodule SqueezeWeb.ActivityControllerTest do
   alias Squeeze.Dashboard
 
   test "lists all activities on index", %{conn: conn} do
-    conn = get conn, activity_path(conn, :index)
+    conn = get(conn, activity_path(conn, :index))
     assert html_response(conn, 200) =~ "Activities"
   end
 
   describe "GET show" do
     test "renders the activity", %{conn: conn, user: user} do
       activity = insert(:activity, user: user)
-      conn = get conn, activity_path(conn, :show, activity)
+      conn = get(conn, activity_path(conn, :show, activity))
       assert html_response(conn, 200) =~ activity.name
     end
   end
 
   describe "GET new" do
     test "renders form", %{conn: conn} do
-      conn = get conn, activity_path(conn, :new)
+      conn = get(conn, activity_path(conn, :new))
       assert html_response(conn, 200) =~ "New Activity"
     end
   end
@@ -37,6 +37,17 @@ defmodule SqueezeWeb.ActivityControllerTest do
       attrs = %{name: nil}
       conn = post conn, activity_path(conn, :create), activity: attrs
       assert html_response(conn, 422) =~ "New Activity"
+    end
+  end
+
+  describe "PATCH mark_complete" do
+    test "Success message is displayed when activity is marked as completed", %{
+      conn: conn,
+      user: user
+    } do
+      activity = insert(:activity, user: user)
+      conn = patch(conn, activity_mark_complete_path(conn, :mark_complete, activity.id))
+      assert get_flash(conn, :info) == "Activity completed!"
     end
   end
 end


### PR DESCRIPTION
- Create new button on activity show page
- Add new route, "/dashboard/activities/:activity_id/mark-complete"
- Update `complete` field on activity to `true` when endpoint runs
- Add controller test for new route