### PR TITLE
Remove sitemap reference in robots.txt

### DIFF
--- a/assets/static/robots.txt
+++ b/assets/static/robots.txt
@@ -4,5 +4,3 @@
 # User-agent: *
 # Disallow: /
 Disallow: /dashboard
-
-Sitemap: https://www.openpace.co/sitemap/index.xml


### PR DESCRIPTION
All of the landing pages have been moved to webflow and this is no longer
required.