### PR TITLE
Add activity loader for Garmin

### DIFF
--- a/lib/squeeze/garmin/history_loader.ex
+++ b/lib/squeeze/garmin/history_loader.ex
@@ -1,0 +1,31 @@
+defmodule Squeeze.Garmin.HistoryLoader do
+  @moduledoc """
+  Loads historical activities from Garmin.
+
+  Garmin has a backfill endpoint which you can send a GET request.
+  Garmin then sends pings to our activity webhook with each activity from the user.
+  """
+
+  alias Squeeze.Accounts.{Credential}
+  alias Squeeze.Garmin.Client
+
+  # GET https://healthapi.garmin.com/wellness-api/rest/backfill/activities
+  # summaryStartTimeInSeconds summaryEndTimeInSeconds
+  # limits to 90 days
+
+  def load_recent(%Credential{} = credential) do
+    trigger_activity_backfill(credential)
+  end
+
+  defp trigger_activity_backfill(credential) do
+    now = Timex.now()
+    end_time = Timex.to_unix(now)
+    start_time = now |> Timex.shift(days: -90) |> Timex.to_unix()
+    query = "summaryStartTimeInSeconds=#{start_time}&summaryEndTimeInSeconds=#{end_time}"
+    url = "https://healthapi.garmin.com/wellness-api/rest/backfill/activities?#{query}"
+
+    credential
+    |> Client.new()
+    |> Client.get(url)
+  end
+end

--- a/test/factories/credential_factory.ex
+++ b/test/factories/credential_factory.ex
@@ -14,6 +14,19 @@ defmodule Squeeze.CredentialFactory do
           user: build(:user)
         }
       end
+
+      def garmin_credential_factory do
+        struct!(
+          credential_factory(),
+          %{
+            provider: "garmin",
+            access_token: nil,
+            refresh_token: nil,
+            token: "abcdefg",
+            token_secret: "abcdefg"
+          }
+        )
+      end
     end
   end
 end

--- a/test/squeeze/garmin/history_loader_test.exs
+++ b/test/squeeze/garmin/history_loader_test.exs
@@ -1,0 +1,29 @@
+defmodule Squeeze.Garmin.HistoryLoaderTest do
+  use Squeeze.DataCase
+
+  import Squeeze.Factory
+  import Tesla.Mock
+
+  alias Squeeze.Garmin.HistoryLoader
+
+  describe "load_recent/1" do
+    setup [:setup_mocks]
+
+    test 'sends a GET request to garmin backfill' do
+      credential = insert(:garmin_credential)
+      assert {:ok, %Tesla.Env{status: 202}} = HistoryLoader.load_recent(credential)
+    end
+  end
+
+  defp setup_mocks(_) do
+    mock fn(%{method: :get, url: url}) ->
+      if String.contains?(url, "/wellness-api/rest/backfill/activities") do
+        %Tesla.Env{status: 202}
+      else
+        %Tesla.Env{status: 400}
+      end
+    end
+
+    {:ok, []}
+  end
+end


### PR DESCRIPTION
Loads historical activities from Garmin.

Garmin has a backfill endpoint which you can send a GET request. Garmin then sends pings to our activity webhook with each activity from the user.
