### PR TITLE
Fix renamer when device_name is nil

### DIFF
--- a/lib/squeeze/namer/activity_renamer.ex
+++ b/lib/squeeze/namer/activity_renamer.ex
@@ -17,9 +17,8 @@ defmodule Squeeze.Namer.ActivityRenamer do
   end
 
   def rename(_, %DetailedActivity{manual: true} = activity), do: activity
-
-  def rename(user, %DetailedActivity{} = activity) do
-    if activity.device_name =~ "Strava" do # Skip all Strava Apps
+  def rename(user, %DetailedActivity{device_name: device_name} = activity) do
+    if device_name && device_name =~ "Strava" do # Skip all Strava Apps
       activity
     else
       rename_activity(user, activity)


### PR DESCRIPTION
```Error message:
(FunctionClauseError) no function clause matching in Kernel.=~/2
(elixir 1.14.0) lib/kernel.ex:2179: Kernel.=~(nil, "Strava")
(squeeze 0.0.1) lib/squeeze/namer/activity_renamer.ex:22: Squeeze.Namer.ActivityRenamer.rename/2
(squeeze 0.0.1) lib/squeeze/namer/renamer_job.ex:19: Squeeze.Namer.RenamerJob.perform/3
(elixir 1.14.0) lib/task/supervised.ex:89: Task.Supervised.invoke_mfa/2
(stdlib 3.14.2.2) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
(squeeze 0.0.1) anonymous fn() in SqueezeWeb.StravaWebhookController.webhook/2```