### PR TITLE
Add elapsed_time and moving_time to activities

### DIFF
--- a/lib/squeeze/dashboard/activity.ex
+++ b/lib/squeeze/dashboard/activity.ex
@@ -50,7 +50,9 @@ defmodule Squeeze.Dashboard.Activity do
     field :distance, :float # in meters
     field :distance_amount, :float
     field :distance_unit, Ecto.Enum, values: [m: 0, km: 1, mi: 2]
-    field :duration, Duration
+    field :duration, Duration # :duration field is deprecated
+    field :moving_time, Duration
+    field :elapsed_time, Duration
     field :start_at, :utc_datetime
     field :start_at_local, :naive_datetime
     field :polyline, :string

--- a/lib/squeeze/file_parser/fit_import.ex
+++ b/lib/squeeze/file_parser/fit_import.ex
@@ -16,6 +16,8 @@ defmodule Squeeze.FileParser.FitImport do
       activity_type: activity_type(data),
       distance: Map.get(session_msg(data), "total_distance"),
       duration: round(Map.get(session_msg(data), "total_elapsed_time")),
+      moving_time: round(Map.get(session_msg(data), "total_elapsed_time")), # TODO
+      elapsed_time: round(Map.get(session_msg(data), "total_elapsed_time")),
       start_at: start_at,
       start_at_local: Timex.shift(start_at, seconds: tz_offset_in_seconds(data)),
       elevation_gain: session_msg(data) |> Map.get("total_ascent") |> cast_float(),

--- a/lib/squeeze/strava/activity_formatter.ex
+++ b/lib/squeeze/strava/activity_formatter.ex
@@ -20,6 +20,8 @@ defmodule Squeeze.Strava.ActivityFormatter do
       activity_type: activity_type(strava_activity),
       distance: strava_activity.distance,
       duration: strava_activity.moving_time,
+      moving_time: strava_activity.moving_time,
+      elapsed_time: strava_activity.elapsed_time,
       start_at: strava_activity.start_date,
       start_at_local: strava_activity.start_date_local,
       elevation_gain: strava_activity.total_elevation_gain,

--- a/lib/squeeze/strava/bulk_import.ex
+++ b/lib/squeeze/strava/bulk_import.ex
@@ -71,6 +71,8 @@ defmodule Squeeze.Strava.BulkImport do
       activity_type: activity_type(activity),
       distance: distance(activity),
       duration: moving_time(activity),
+      moving_time: moving_time(activity),
+      elapsed_time: elapsed_time(activity),
       start_at: start_at(activity),
       start_at_local: start_at(activity),
       elevation_gain: to_float(activity["Elevation Gain"]),
@@ -90,6 +92,11 @@ defmodule Squeeze.Strava.BulkImport do
 
   defp moving_time(activity) do
     {duration, _} = activity["Moving Time"] |> Integer.parse()
+    duration
+  end
+
+  defp elapsed_time(activity) do
+    {duration, _} = activity["Elapsed Time"] |> Integer.parse()
     duration
   end
 

--- a/priv/repo/migrations/20230206021940_add_elapsed_time_to_activities.exs
+++ b/priv/repo/migrations/20230206021940_add_elapsed_time_to_activities.exs
@@ -1,0 +1,10 @@
+defmodule Squeeze.Repo.Migrations.AddElapsedTimeToActivities do
+  use Ecto.Migration
+
+  def change do
+    alter table(:activities) do
+      add :moving_time, :integer
+      add :elapsed_time, :integer
+    end
+  end
+end


### PR DESCRIPTION
Now we'll deprecate activity.duration and use moving_time. Need to write a script to fetch the existing elapsed_times from strava.